### PR TITLE
feat: remove unnecessary generics from CommandHandlingTestFixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Test command handling logic using the built-in test fixture support:
 public class BookHandlingTest {
 
     @Test
-    public void canBePurchased(@Autowired CommandHandlingTestFixture<Book, PurchaseBookCommand, String> fixture) {
+    public void canBePurchased(@Autowired CommandHandlingTestFixture<PurchaseBookCommand> fixture) {
         fixture.givenNothing()
                 .when(new PurchaseBookCommand("4711", "JRR Tolkien", "LOTR", 435))
                 .expectSuccessfulExecution()

--- a/example-application/src/test/java/com/opencqrs/example/domain/book/BookHandlingTest.java
+++ b/example-application/src/test/java/com/opencqrs/example/domain/book/BookHandlingTest.java
@@ -20,7 +20,7 @@ public class BookHandlingTest {
     private ReaderRepository readerRepository;
 
     @Test
-    public void canBePurchased(@Autowired CommandHandlingTestFixture<Book, PurchaseBookCommand, String> fixture) {
+    public void canBePurchased(@Autowired CommandHandlingTestFixture<PurchaseBookCommand> fixture) {
         fixture.givenNothing()
                 .when(new PurchaseBookCommand("4711", "JRR Tolkien", "LOTR", 435))
                 .expectSuccessfulExecution()
@@ -28,8 +28,7 @@ public class BookHandlingTest {
     }
 
     @Test
-    public void canBeBorrowedIfReaderExists(
-            @Autowired CommandHandlingTestFixture<Book, BorrowBookCommand, Void> fixture) {
+    public void canBeBorrowedIfReaderExists(@Autowired CommandHandlingTestFixture<BorrowBookCommand> fixture) {
         var reader = UUID.randomUUID();
         doReturn(true).when(readerRepository).existsById(reader);
 
@@ -40,7 +39,7 @@ public class BookHandlingTest {
     }
 
     @Test
-    public void canBeReturnedIfLent(@Autowired CommandHandlingTestFixture<Book, ReturnBookCommand, Void> fixture) {
+    public void canBeReturnedIfLent(@Autowired CommandHandlingTestFixture<ReturnBookCommand> fixture) {
         fixture.givenState(new Book("4711", 435, Set.of(), new Book.Lending.Lent(UUID.randomUUID())))
                 .when(new ReturnBookCommand("4711"))
                 .expectSuccessfulExecution()
@@ -49,7 +48,7 @@ public class BookHandlingTest {
 
     @Test
     public void cannotBeBorrowedIfTooManyPagesDamaged(
-            @Autowired CommandHandlingTestFixture<Book, BorrowBookCommand, Void> fixture) {
+            @Autowired CommandHandlingTestFixture<BorrowBookCommand> fixture) {
         var reader = UUID.randomUUID();
         doReturn(true).when(readerRepository).existsById(reader);
 

--- a/example-application/src/test/java/com/opencqrs/example/domain/book/PageHandlingTest.java
+++ b/example-application/src/test/java/com/opencqrs/example/domain/book/PageHandlingTest.java
@@ -13,8 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class PageHandlingTest {
 
     @Test
-    public void pageMarkedAsDamaged(
-            @Autowired CommandHandlingTestFixture<Page, MarkBookPageDamagedCommand, Void> fixture) {
+    public void pageMarkedAsDamaged(@Autowired CommandHandlingTestFixture<MarkBookPageDamagedCommand> fixture) {
         fixture.givenNothing()
                 .when(new MarkBookPageDamagedCommand("4711", 42L, UUID.randomUUID()))
                 .expectSuccessfulExecution()

--- a/example-application/src/test/java/com/opencqrs/example/domain/reader/ReaderHandlingTest.java
+++ b/example-application/src/test/java/com/opencqrs/example/domain/reader/ReaderHandlingTest.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class ReaderHandlingTest {
 
     @Test
-    public void canRegister(@Autowired CommandHandlingTestFixture<UUID, RegisterReaderCommand, UUID> fixture) {
+    public void canRegister(@Autowired CommandHandlingTestFixture<RegisterReaderCommand> fixture) {
         var readerId = UUID.randomUUID();
         fixture.givenNothing()
                 .when(new RegisterReaderCommand(readerId, "Hugo Tester"))

--- a/framework-test/src/main/java/com/opencqrs/framework/command/CommandHandlingTestAutoConfiguration.java
+++ b/framework-test/src/main/java/com/opencqrs/framework/command/CommandHandlingTestAutoConfiguration.java
@@ -48,13 +48,11 @@ public class CommandHandlingTestAutoConfiguration {
                 BeanDefinition bd = registry.getBeanDefinition(beanName);
                 if (CommandHandlerDefinition.class.getName().equals(bd.getBeanClassName())) {
                     ResolvableType resolvableType = bd.getResolvableType();
-                    Class<?> instanceType = resolvableType.resolveGeneric(0);
                     Class<?> commandType = resolvableType.resolveGeneric(1);
-                    Class<?> resultType = resolvableType.resolveGeneric(2);
 
-                    if (instanceType != null && commandType != null && resultType != null) {
-                        ResolvableType fixtureType = ResolvableType.forClassWithGenerics(
-                                CommandHandlingTestFixture.class, instanceType, commandType, resultType);
+                    if (commandType != null) {
+                        ResolvableType fixtureType =
+                                ResolvableType.forClassWithGenerics(CommandHandlingTestFixture.class, commandType);
 
                         bd.setLazyInit(true);
 
@@ -95,11 +93,9 @@ public class CommandHandlingTestAutoConfiguration {
                             if (factoryMethod.get() != null) {
                                 ResolvableType factoryMethodReturnType =
                                         ResolvableType.forMethodReturnType(factoryMethod.get());
-                                ResolvableType stateType = factoryMethodReturnType.getGeneric(0);
                                 ResolvableType commandType = factoryMethodReturnType.getGeneric(1);
-                                ResolvableType resultType = factoryMethodReturnType.getGeneric(2);
                                 ResolvableType fixtureType = ResolvableType.forClassWithGenerics(
-                                        CommandHandlingTestFixture.class, stateType, commandType, resultType);
+                                        CommandHandlingTestFixture.class, commandType);
 
                                 RootBeanDefinition fixture = new RootBeanDefinition();
                                 fixture.setTargetType(fixtureType);

--- a/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingConfiguration.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingConfiguration.java
@@ -3,7 +3,6 @@ package com.opencqrs.framework.command;
 
 import com.opencqrs.framework.MyEvent;
 import com.opencqrs.framework.State;
-import java.util.UUID;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -22,21 +21,21 @@ public class CommandHandlingConfiguration {
     }
 
     @Bean
-    public CommandHandlerDefinition<State, MyCommand, Void> chdNoDependency() {
+    public CommandHandlerDefinition<State, MyCommand1, Void> chdNoDependency() {
         return new CommandHandlerDefinition<>(
-                State.class, MyCommand.class, (CommandHandler.ForCommand<State, MyCommand, Void>)
+                State.class, MyCommand1.class, (CommandHandler.ForCommand<State, MyCommand1, Void>)
                         (command, commandEventPublisher) -> null);
     }
 
     @Bean
-    public CommandHandlerDefinition<State, MyCommand, UUID> chdUnresolvableDependency(MyCommand noSuchBean) {
+    public CommandHandlerDefinition<State, MyCommand2, Void> chdUnresolvableDependency(Runnable noSuchBean) {
         return new CommandHandlerDefinition<>(
-                State.class, MyCommand.class, (CommandHandler.ForCommand<State, MyCommand, UUID>)
+                State.class, MyCommand2.class, (CommandHandler.ForCommand<State, MyCommand2, Void>)
                         (command, commandEventPublisher) -> null);
     }
 
     @CommandHandling
-    public String handle(State instance, MyCommand command) {
+    public String handle(State instance, MyCommand3 command) {
         return "test";
     }
 
@@ -49,13 +48,13 @@ public class CommandHandlingConfiguration {
                 RootBeanDefinition chd = new RootBeanDefinition();
                 chd.setBeanClass(CommandHandlerDefinition.class);
                 chd.setTargetType(ResolvableType.forClassWithGenerics(
-                        CommandHandlerDefinition.class, State.class, MyCommand.class, Boolean.class));
+                        CommandHandlerDefinition.class, State.class, MyCommand4.class, Void.class));
 
                 ConstructorArgumentValues values = new ConstructorArgumentValues();
                 values.addGenericArgumentValue(State.class);
-                values.addGenericArgumentValue(MyCommand.class);
-                values.addGenericArgumentValue((CommandHandler.ForCommand<State, MyCommand, Boolean>)
-                        (command, commandEventPublisher) -> null);
+                values.addGenericArgumentValue(MyCommand4.class);
+                values.addGenericArgumentValue(
+                        (CommandHandler.ForCommand<State, MyCommand4, Void>) (command, commandEventPublisher) -> null);
 
                 chd.setConstructorArgumentValues(values);
                 registry.registerBeanDefinition("myProgrammaticCommandHandlerDefinition", chd);

--- a/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingTestAutoConfigurationTest.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingTestAutoConfigurationTest.java
@@ -4,8 +4,6 @@ package com.opencqrs.framework.command;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.opencqrs.framework.State;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.UnsatisfiedDependencyException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -37,8 +35,8 @@ public class CommandHandlingTestAutoConfigurationTest {
     @Test
     public void initialized_CommandHandlingTestFixture_beanMethodNoDependency() {
         contextRunner.run(context -> {
-            assertThat(context.getBeanNamesForType(ResolvableType.forClassWithGenerics(
-                            CommandHandlingTestFixture.class, State.class, MyCommand.class, Void.class)))
+            assertThat(context.getBeanNamesForType(
+                            ResolvableType.forClassWithGenerics(CommandHandlingTestFixture.class, MyCommand1.class)))
                     .singleElement()
                     .satisfies(beanName -> {
                         assertThat(context).getBean(beanName).isInstanceOf(CommandHandlingTestFixture.class);
@@ -49,8 +47,8 @@ public class CommandHandlingTestAutoConfigurationTest {
     @Test
     public void lazyInitialized_CommandHandlingTestFixture_beanMethodWithUnresolvableDependency() {
         contextRunner.run(context -> {
-            assertThat(context.getBeanNamesForType(ResolvableType.forClassWithGenerics(
-                            CommandHandlingTestFixture.class, State.class, MyCommand.class, UUID.class)))
+            assertThat(context.getBeanNamesForType(
+                            ResolvableType.forClassWithGenerics(CommandHandlingTestFixture.class, MyCommand2.class)))
                     .singleElement()
                     .satisfies(beanName -> {
                         assertThatThrownBy(() -> context.getBean(beanName))
@@ -63,8 +61,8 @@ public class CommandHandlingTestAutoConfigurationTest {
     @Test
     public void initialized_CommandHandlingTestFixture_for_CommandHandlingAnnotation() {
         contextRunner.run(context -> {
-            assertThat(context.getBeanNamesForType(ResolvableType.forClassWithGenerics(
-                            CommandHandlingTestFixture.class, State.class, MyCommand.class, String.class)))
+            assertThat(context.getBeanNamesForType(
+                            ResolvableType.forClassWithGenerics(CommandHandlingTestFixture.class, MyCommand3.class)))
                     .singleElement()
                     .satisfies(beanName -> {
                         assertThat(context).getBean(beanName).isInstanceOf(CommandHandlingTestFixture.class);
@@ -75,8 +73,8 @@ public class CommandHandlingTestAutoConfigurationTest {
     @Test
     public void initialized_CommandHandlingTestFixture_programmaticBeanRegistration() {
         contextRunner.run(context -> {
-            assertThat(context.getBeanNamesForType(ResolvableType.forClassWithGenerics(
-                            CommandHandlingTestFixture.class, State.class, MyCommand.class, Boolean.class)))
+            assertThat(context.getBeanNamesForType(
+                            ResolvableType.forClassWithGenerics(CommandHandlingTestFixture.class, MyCommand4.class)))
                     .singleElement()
                     .satisfies(beanName -> {
                         assertThat(context).getBean(beanName).isInstanceOf(CommandHandlingTestFixture.class);

--- a/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingTestFixtureTest.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingTestFixtureTest.java
@@ -314,7 +314,7 @@ public class CommandHandlingTestFixtureTest {
                                                     return new State(true);
                                                 }));
 
-                CommandHandlingTestFixture<State, DummyCommand, Void> givenCommandFixture = fixtureBuilder.using(
+                CommandHandlingTestFixture<DummyCommand> givenCommandFixture = fixtureBuilder.using(
                         State.class, (CommandHandler.ForInstanceAndCommand<State, DummyCommand, Void>) (i, c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -886,7 +886,7 @@ public class CommandHandlingTestFixtureTest {
             @ParameterizedTest
             @ValueSource(booleans = {true, false})
             public void commandSubjectionConditionPristineViolated_byCommand_successfully(boolean specified) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -906,7 +906,7 @@ public class CommandHandlingTestFixtureTest {
             @ParameterizedTest
             @ValueSource(booleans = {true, false})
             public void commandSubjectionConditionPristineViolated_byStubbing_successfully(boolean specified) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -927,7 +927,7 @@ public class CommandHandlingTestFixtureTest {
             @ParameterizedTest
             @ValueSource(booleans = {true, false})
             public void commandSubjectionConditionPristineNotViolated_failing(boolean specified) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -947,7 +947,7 @@ public class CommandHandlingTestFixtureTest {
             @ParameterizedTest
             @ValueSource(booleans = {true, false})
             public void commandSubjectionConditionExistsViolated_successfully(boolean specified) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -966,7 +966,7 @@ public class CommandHandlingTestFixtureTest {
             @ParameterizedTest
             @ValueSource(booleans = {true, false})
             public void commandSubjectionConditionExistsNotViolated_byCommand_failing(boolean specified) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -987,7 +987,7 @@ public class CommandHandlingTestFixtureTest {
             @ParameterizedTest
             @ValueSource(booleans = {true, false})
             public void commandSubjectionConditionExistsNotViolated_byStubbing_failing(boolean specified) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -1008,7 +1008,7 @@ public class CommandHandlingTestFixtureTest {
 
             @Test
             public void commandSubjectConditionNone_mustNotBeSpecified() {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;
@@ -1023,7 +1023,7 @@ public class CommandHandlingTestFixtureTest {
             @EnumSource(value = Command.SubjectCondition.class, mode = EnumSource.Mode.EXCLUDE, names = "NONE")
             @NullSource
             public void commandSubjectConditionMustNotBeUsedWithStateStubbing(Command.SubjectCondition condition) {
-                CommandHandlingTestFixture<State, DummyCommand, Long> fixture =
+                CommandHandlingTestFixture<DummyCommand> fixture =
                         subject.using(State.class, (CommandHandler.ForCommand<State, DummyCommand, Long>) (c, p) -> {
                             p.publish(new EventA("test"));
                             return null;

--- a/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingTestSliceTest.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/CommandHandlingTestSliceTest.java
@@ -7,8 +7,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opencqrs.esdb.client.EsdbClient;
 import com.opencqrs.esdb.client.EsdbClientAutoConfiguration;
-import com.opencqrs.framework.State;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,13 +24,13 @@ public class CommandHandlingTestSliceTest {
 
     @Test
     public void fixtureAutoCreatedWithProperGenericTypes_beanNoDependency(
-            @Autowired ObjectProvider<CommandHandlingTestFixture<State, MyCommand, Void>> fixture) {
+            @Autowired ObjectProvider<CommandHandlingTestFixture<MyCommand1>> fixture) {
         assertThat(fixture.getIfAvailable()).isNotNull();
     }
 
     @Test
     public void fixtureAutoCreatedWithProperGenericTypes_beanUnresolvableDependency(
-            @Autowired ObjectProvider<CommandHandlingTestFixture<State, MyCommand, UUID>> fixture) {
+            @Autowired ObjectProvider<CommandHandlingTestFixture<MyCommand2>> fixture) {
         assertThatThrownBy(fixture::getIfAvailable)
                 .hasCauseInstanceOf(UnsatisfiedDependencyException.class)
                 .hasMessageContaining("chdUnresolvableDependency");
@@ -40,19 +38,18 @@ public class CommandHandlingTestSliceTest {
 
     @Test
     public void fixtureAutoCreatedWithProperGenericTypes_beanCommandHandling(
-            @Autowired ObjectProvider<CommandHandlingTestFixture<State, MyCommand, String>> fixture) {
+            @Autowired ObjectProvider<CommandHandlingTestFixture<MyCommand3>> fixture) {
         assertThat(fixture.getIfAvailable()).isNotNull();
     }
 
     @Test
     public void fixtureAutoCreatedWithProperGenericTypes_programmaticBeanRegistration(
-            @Autowired ObjectProvider<CommandHandlingTestFixture<State, MyCommand, Boolean>> fixture) {
+            @Autowired ObjectProvider<CommandHandlingTestFixture<MyCommand4>> fixture) {
         assertThat(fixture.getIfAvailable()).isNotNull();
     }
 
     @Test
-    public void fixtureNotCreated(
-            @Autowired ObjectProvider<CommandHandlingTestFixture<String, Command, Boolean>> fixture) {
+    public void fixtureNotCreated(@Autowired ObjectProvider<CommandHandlingTestFixture<Command>> fixture) {
         assertThat(fixture.getIfAvailable()).isNull();
     }
 

--- a/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand1.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand1.java
@@ -1,0 +1,9 @@
+/* Copyright (C) 2025 OpenCQRS and contributors */
+package com.opencqrs.framework.command;
+
+public class MyCommand1 implements Command {
+    @Override
+    public String getSubject() {
+        return "irrelevant";
+    }
+}

--- a/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand2.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand2.java
@@ -1,0 +1,9 @@
+/* Copyright (C) 2025 OpenCQRS and contributors */
+package com.opencqrs.framework.command;
+
+public class MyCommand2 implements Command {
+    @Override
+    public String getSubject() {
+        return "irrelevant";
+    }
+}

--- a/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand3.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand3.java
@@ -1,7 +1,7 @@
 /* Copyright (C) 2025 OpenCQRS and contributors */
 package com.opencqrs.framework.command;
 
-public class MyCommand implements Command {
+public class MyCommand3 implements Command {
     @Override
     public String getSubject() {
         return "irrelevant";

--- a/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand4.java
+++ b/framework-test/src/test/java/com/opencqrs/framework/command/MyCommand4.java
@@ -1,0 +1,9 @@
+/* Copyright (C) 2025 OpenCQRS and contributors */
+package com.opencqrs.framework.command;
+
+public class MyCommand4 implements Command {
+    @Override
+    public String getSubject() {
+        return "irrelevant";
+    }
+}

--- a/framework/src/main/java/com/opencqrs/framework/command/CommandRouter.java
+++ b/framework/src/main/java/com/opencqrs/framework/command/CommandRouter.java
@@ -70,17 +70,6 @@ public final class CommandRouter {
         }
         this.commandHandlerDefinitions = commandHandlerDefinitions.stream()
                 .collect(toMap(CommandHandlerDefinition::commandClass, Function.identity()));
-
-        // TODO: won't work due to generics hell
-        /*this.stateRebuildingHandlerDefinitions = stateRebuildingHandlerDefinitions
-        .stream()
-        .collect(
-                groupingBy(
-                        StateRebuildingHandlerDefinition::instanceClass,
-                        toList()
-                )
-        );*/
-
         this.stateRebuildingHandlerDefinitions = new HashMap<>();
         stateRebuildingHandlerDefinitions.forEach(srhd -> this.stateRebuildingHandlerDefinitions
                 .computeIfAbsent(srhd.instanceClass(), clazz -> new ArrayList<>())

--- a/mkdocs/docs/tutorials/06_testing/index.md
+++ b/mkdocs/docs/tutorials/06_testing/index.md
@@ -6,7 +6,7 @@ In this tutorial you will learn, how to write unit test for your _command handle
 tests verify the domain logic by focussing on:
 
 1.  sending commands to command handlers for execution
-2.  implicitly verifying that the write mode is properly rebuilt
+2.  implicitly verifying that the write model is properly rebuilt
 3.  verifying the publication of new events
 
 ## Preparing the Test Fixture
@@ -38,7 +38,7 @@ public class BookHandlingTest {
     private LateChargeCalculator lateChargeCalculator;
 
     @Test
-    public void canBePurchased(@Autowired CommandHandlingTestFixture<Void, PurchaseBookCommand, Void> fixture) {
+    public void canBePurchased(@Autowired CommandHandlingTestFixture<PurchaseBookCommand> fixture) {
         // ...
     }
 }
@@ -53,11 +53,7 @@ The test contains the following essential elements:
     out of scope of this test class and hence will be mocked (lines 20-21).
 3.  It defines an initial test method with an autowired `CommandHandlingTestFixture`{ title="com.opencqrs.framework.command.CommandHandlingTestFixture" }.
     This fixture substitutes the command execution via the `CommandRouter`{ title="com.opencqrs.framework.command.CommandRouter" }.
-    The command handler to test is identified by the fixture's generic types in the following order (lines 23-26):
-    
-    1.  the type of the state rebuilt prior to executing the command (`Void`)
-    2.  the type of the command executed (`PurchaseBookCommand`)
-    3.  the command handler's return type (`Void`)
+    The command handler to test is identified by the fixture's generic command type `PurchaseBookCommand` (lines 23-26).
 
 For the remainder of this tutorial we will be implementing further tests, by simply adding them to the `BookHandlingTest` class.
 All tests can be executed directly from the IDE or as follows:
@@ -91,7 +87,7 @@ us express this using its [Given When Then](https://martinfowler.com/bliki/Given
 
 ```java
 @Test
-public void canBePurchased(@Autowired CommandHandlingTestFixture<Void, PurchaseBookCommand, Void> fixture) {
+public void canBePurchased(@Autowired CommandHandlingTestFixture<PurchaseBookCommand> fixture) {
     var id = UUID.randomUUID();
     
     fixture
@@ -131,7 +127,7 @@ to be published, as well as the due date being returned from the command handler
 
 ```java linenums="1"
 @Test
-public void canBeBorrowed(@Autowired CommandHandlingTestFixture<Book, BorrowBookCommand, Instant> fixture) {
+public void canBeBorrowed(@Autowired CommandHandlingTestFixture<BorrowBookCommand> fixture) {
     var id = UUID.randomUUID();
 
     fixture
@@ -146,7 +142,7 @@ public void canBeBorrowed(@Autowired CommandHandlingTestFixture<Book, BorrowBook
             )
             .when(new BorrowBookCommand(id))
             .expectSuccessfulExecution()
-            .expectResultSatisfying(instant -> assertThat(instant).isInTheFuture())
+            .expectResultSatisfying((Instant instant) -> assertThat(instant).isInTheFuture())
             .expectSingleEventSatisfying((BookLentEvent e) -> {
                 assertThat(e.id()).isEqualTo(id);
                 assertThat(e.returnDueAt()).isInTheFuture();
@@ -163,7 +159,7 @@ verified by another test for the same command handler, which expects no events b
 
 ```java hl_lines="22-23"
 @Test
-public void cannotBeBorrowedIfAlreadyLent(@Autowired CommandHandlingTestFixture<Book, BorrowBookCommand, Instant> fixture) {
+public void cannotBeBorrowedIfAlreadyLent(@Autowired CommandHandlingTestFixture<BorrowBookCommand> fixture) {
     var id = UUID.randomUUID();
 
     fixture
@@ -196,7 +192,7 @@ decides, if the return is overdue or not. So, for returns without late charge th
 
 ```java
 @Test
-public void canBeReturnedWithoutLateCharge(@Autowired CommandHandlingTestFixture<Book, ReturnBookCommand, Void> fixture) {
+public void canBeReturnedWithoutLateCharge(@Autowired CommandHandlingTestFixture<ReturnBookCommand> fixture) {
     var id = UUID.randomUUID();
     var now = Instant.now();
 
@@ -227,7 +223,7 @@ the event publication, as follows:
 
 ```java hl_lines="6-8 28"
     @Test
-    public void canBeReturnedWithLateChargeCalculated(@Autowired CommandHandlingTestFixture<Book, ReturnBookCommand, Void> fixture) {
+    public void canBeReturnedWithLateChargeCalculated(@Autowired CommandHandlingTestFixture<ReturnBookCommand> fixture) {
         var id = UUID.randomUUID();
         var now = Instant.now();
 


### PR DESCRIPTION
BREAKING CHANGE: breaks existing usages of CommandHandlingTestFixture