### PR TITLE
Fix macro variable displayed in docs header and metadata

### DIFF
--- a/mkdocs/docs/reference/events/index.md
+++ b/mkdocs/docs/reference/events/index.md
@@ -1,5 +1,5 @@
 ---
-description: How events are represented within {{ custom.framework_name }}
+description: How events are represented within OpenCQRS
 ---
 
 Events published or consumed using {{ custom.framework_name }} are stored within the {{ esdb_ref() }}, which in turn

--- a/mkdocs/docs/reference/extension_points/index.md
+++ b/mkdocs/docs/reference/extension_points/index.md
@@ -1,6 +1,6 @@
 ---
 title: Extension Points
-description: Building Application Components using {{ custom.framework_name }}
+description: Building Application Components using OpenCQRS
 ---
 
 {{ custom.framework_name }} offers three core extension points for application developers to implement their CQRS applications:

--- a/mkdocs/docs/reference/modules/index.md
+++ b/mkdocs/docs/reference/modules/index.md
@@ -1,5 +1,5 @@
 ---
-description: An overview of the {{ custom.framework_name }} modules and when to use them
+description: An overview of the OpenCQRS modules and when to use them
 ---
 
 The following diagram depicts the {{ custom.framework_name }} framework modules, their categorization and interdependencies:

--- a/mkdocs/docs/tutorials/01_setup/index.md
+++ b/mkdocs/docs/tutorials/01_setup/index.md
@@ -1,5 +1,5 @@
 ---
-description: Creating an initial {{ custom.framework_name }} Spring Boot application connected to an {{ esdb_name() }}
+description: Creating an initial OpenCQRS Spring Boot application connected to an {{ esdb_name() }}
 ---
 
 This tutorial will enable you to develop [Spring Boot](https://spring.io/projects/spring-boot) {{ custom.framework_name }} applications 

--- a/mkdocs/docs/tutorials/README.md
+++ b/mkdocs/docs/tutorials/README.md
@@ -1,6 +1,6 @@
 ---
-title: Getting Started with {{ custom.framework_name }}
-description: Learning the core concepts and how to build {{ custom.framework_name }} applications
+title: Getting Started with OpenCQRS
+description: Learning the core concepts and how to build OpenCQRS applications
 ---
 
 Welcome to the __Getting Started__ series for {{ custom.framework_name }}! This tutorial series will guide you through the 


### PR DESCRIPTION
After intensive testing, it seems that it is not possible to use macro variables in the metadata. Using them will result in the variable placeholder being injected in the metadata, as well as into the header/banner (which uses title) when the user scrolls down.

Wrong Banner:
![wrong_banner](https://github.com/user-attachments/assets/e2164462-4d69-454e-8eac-fab3c1de55e0)

Wrong MetaData:
![wrong_metadata](https://github.com/user-attachments/assets/ca66a2c5-7bbb-4414-85d9-0baefdca2e5c)
