### PR TITLE
feat: Add readEventTypes API for event type discovery

### DIFF
--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/EventTypeMetadata.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/EventTypeMetadata.java
@@ -1,0 +1,15 @@
+/* Copyright (C) 2025 OpenCQRS and contributors */
+package com.opencqrs.esdb.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Represents metadata about an event type in the event store.
+ *
+ * @param eventType the event type identifier
+ * @param isPhantom true if the event type has been registered via schema but no events have been written yet
+ * @param schema optional JSON schema for this event type, null if no schema has been registered
+ * @see EsdbClient#readEventTypes()
+ */
+public record EventTypeMetadata(@NotBlank String eventType, boolean isPhantom, JsonNode schema) {}

--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/Marshaller.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/Marshaller.java
@@ -76,17 +76,37 @@ public interface Marshaller {
     ResponseElement fromReadOrObserveResponseLine(String line);
 
     /**
+     * Used by {@link EsdbClient#readEventTypes()} to transform the HTTP request to be sent to the event store.
+     *
+     * @return the JSON HTTP request body as string
+     */
+    String toReadEventTypesRequest();
+
+    /**
+     * Used by {@link EsdbClient#readEventTypes()} to transform an ND-JSON line from the HTTP response stream to a
+     * {@link ResponseElement}.
+     *
+     * @param line the ND-JSON element as string
+     * @return an unmarshalled {@link ResponseElement}
+     */
+    ResponseElement fromReadEventTypesResponseLine(String line);
+
+    /**
      * Sealed interface representing a deserialized ND-JSON response line transformed via
      * {@link #fromReadOrObserveResponseLine(String)}.
      *
      * @see Event
      */
-    sealed interface ResponseElement permits Marshaller.ResponseElement.Heartbeat, Event {
+    sealed interface ResponseElement
+            permits Marshaller.ResponseElement.Heartbeat, Event, Marshaller.ResponseElement.EventTypeElement {
 
         /**
          * Represents a heart beat returned from the event store to ensure the underlying HTTP connection is kept alive.
          */
         record Heartbeat() implements ResponseElement {}
+
+        /** Represents an event type returned from the event store when reading event types. */
+        record EventTypeElement(EventTypeMetadata metadata) implements ResponseElement {}
     }
 
     /**

--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/jackson/JacksonMarshaller.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/jackson/JacksonMarshaller.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opencqrs.esdb.client.*;
 import com.opencqrs.esdb.client.eventql.EventQueryProcessingError;
@@ -141,6 +142,36 @@ public class JacksonMarshaller implements Marshaller {
                             event.payload.datacontenttype,
                             event.payload.hash,
                             event.payload.predecessorhash);
+                case JacksonResponseElement.EventType eventType ->
+                    throw new ClientException.MarshallingException(
+                            new IllegalArgumentException("Unexpected eventType in read/observe response"));
+            };
+        } catch (JsonProcessingException e) {
+            throw new ClientException.MarshallingException(e);
+        }
+    }
+
+    @Override
+    public String toReadEventTypesRequest() {
+        try {
+            return objectMapper.writeValueAsString(Map.of());
+        } catch (JsonProcessingException e) {
+            throw new ClientException.MarshallingException(e);
+        }
+    }
+
+    @Override
+    public ResponseElement fromReadEventTypesResponseLine(String line) {
+        try {
+            JacksonResponseElement jacksonResponseElement = objectMapper.readValue(line, JacksonResponseElement.class);
+            return switch (jacksonResponseElement) {
+                case JacksonResponseElement.Heartbeat heartbeat -> new ResponseElement.Heartbeat();
+                case JacksonResponseElement.EventType eventType ->
+                    new ResponseElement.EventTypeElement(new EventTypeMetadata(
+                            eventType.payload.eventType, eventType.payload.isPhantom, eventType.payload.schema));
+                case JacksonResponseElement.Event event ->
+                    throw new ClientException.MarshallingException(
+                            new IllegalArgumentException("Unexpected event in readEventTypes response"));
             };
         } catch (JsonProcessingException e) {
             throw new ClientException.MarshallingException(e);
@@ -203,6 +234,7 @@ public class JacksonMarshaller implements Marshaller {
     @JsonSubTypes({
         @JsonSubTypes.Type(value = JacksonResponseElement.Heartbeat.class, name = "heartbeat"),
         @JsonSubTypes.Type(value = JacksonResponseElement.Event.class, name = "event"),
+        @JsonSubTypes.Type(value = JacksonResponseElement.EventType.class, name = "eventType"),
     })
     sealed interface JacksonResponseElement {
         record Heartbeat() implements JacksonResponseElement {}
@@ -219,6 +251,10 @@ public class JacksonMarshaller implements Marshaller {
                     @NotBlank String datacontenttype,
                     @NotBlank String hash,
                     @NotBlank String predecessorhash) {}
+        }
+
+        record EventType(@NotNull Payload payload) implements JacksonResponseElement {
+            record Payload(@NotBlank String eventType, boolean isPhantom, JsonNode schema) {}
         }
     }
 


### PR DESCRIPTION
Implements the readEventTypes endpoint to retrieve all event types from the event store, including both active event types (with written events) and phantom event types (registered via schema only).

Changes:
- Add EventTypeMetadata record with eventType, isPhantom, and schema (JsonNode)
- Add toReadEventTypesRequest and fromReadEventTypesResponseLine to Marshaller
- Add EventTypeElement as new ResponseElement type
- Implement readEventTypes in JacksonMarshaller with NDJSON streaming support
- Add readEventTypes method to EsdbClient using AbstractLineSubscriber pattern
- Add integration tests for readEventTypes functionality

The implementation follows the same patterns as existing read/observe operations and maintains full backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)