### PR TITLE
feat: Add readEventType API for single event type retrieval

### DIFF
--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/EsdbClient.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/EsdbClient.java
@@ -199,6 +199,28 @@ public final class EsdbClient implements AutoCloseable {
     }
 
     /**
+     * Reads metadata for a specific event type from the underlying event store.
+     *
+     * @param eventType the event type to read
+     * @return the {@link EventTypeMetadata} for the requested event type
+     * @throws ClientException.TransportException in case of connection or network errors
+     * @throws ClientException.HttpException in case of errors depending on the HTTP status code, e.g. 404 if the event
+     *     type does not exist
+     * @throws ClientException.MarshallingException in case of serialization errors, typically caused by the associated
+     *     {@link Marshaller}
+     */
+    public EventTypeMetadata readEventType(String eventType) throws ClientException {
+        HttpRequest httpRequest = newJsonRequest("/api/v1/read-event-type")
+                .POST(HttpRequest.BodyPublishers.ofString(marshaller.toReadEventTypeRequest(eventType)))
+                .build();
+
+        var response = httpRequestErrorHandler.handle(
+                httpRequest, headers -> HttpResponse.BodySubscribers.ofString(Util.fromHttpHeaders(headers)));
+
+        return marshaller.fromReadEventTypeResponse(response);
+    }
+
+    /**
      * Queries the underlying event store using <a
      * href="https://docs.eventsourcingdb.io/reference/eventql/">EventQL</a>.
      *

--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/EventTypeMetadata.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/EventTypeMetadata.java
@@ -1,0 +1,15 @@
+/* Copyright (C) 2025 OpenCQRS and contributors */
+package com.opencqrs.esdb.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Represents metadata about an event type in the event store.
+ *
+ * @param eventType the event type identifier
+ * @param isPhantom true if the event type has been registered via schema but no events have been written yet
+ * @param schema optional JSON schema for this event type, null if no schema has been registered
+ * @see EsdbClient#readEventType(String)
+ */
+public record EventTypeMetadata(@NotBlank String eventType, boolean isPhantom, JsonNode schema) {}

--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/Marshaller.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/Marshaller.java
@@ -76,6 +76,23 @@ public interface Marshaller {
     ResponseElement fromReadOrObserveResponseLine(String line);
 
     /**
+     * Used by {@link EsdbClient#readEventType(String)} to transform the HTTP request to be sent to the event store.
+     *
+     * @param eventType the event type to read
+     * @return the JSON HTTP request body as string
+     */
+    String toReadEventTypeRequest(String eventType);
+
+    /**
+     * Used by {@link EsdbClient#readEventType(String)} to transform the HTTP response body to a
+     * {@link EventTypeMetadata}.
+     *
+     * @param response the JSON HTTP response body as string
+     * @return the unmarshalled {@link EventTypeMetadata}
+     */
+    EventTypeMetadata fromReadEventTypeResponse(String response);
+
+    /**
      * Sealed interface representing a deserialized ND-JSON response line transformed via
      * {@link #fromReadOrObserveResponseLine(String)}.
      *

--- a/esdb-client/src/test/java/com/opencqrs/esdb/client/EsdbClientIntegrationTest.java
+++ b/esdb-client/src/test/java/com/opencqrs/esdb/client/EsdbClientIntegrationTest.java
@@ -712,6 +712,42 @@ public class EsdbClientIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("/api/v1/read-event-type")
+    public class ReadEventType {
+
+        @Test
+        public void readSingleEventType() {
+            // Arrange: Write an event to create the event type
+            String subject = randomSubject();
+
+            client.write(
+                    List.of(new EventCandidate(
+                            TEST_SOURCE,
+                            subject,
+                            "com.opencqrs.books-added.v1",
+                            objectMapper.convertValue(new BookAddedEvent("Author", "Title"), Map.class))),
+                    List.of());
+
+            // Act: Read the specific event type
+            EventTypeMetadata eventTypeMetadata = client.readEventType("com.opencqrs.books-added.v1");
+
+            // Assert
+            assertThat(eventTypeMetadata.eventType()).isEqualTo("com.opencqrs.books-added.v1");
+            assertThat(eventTypeMetadata.isPhantom()).isFalse();
+            assertThat(eventTypeMetadata.schema()).isNull();
+        }
+
+        @Test
+        public void readNonExistentEventTypeThrows404() {
+            // Act & Assert: Reading non-existent event type should throw 404
+            assertThatThrownBy(() -> client.readEventType("com.opencqrs.non.existent"))
+                    .isInstanceOfSatisfying(ClientException.HttpException.HttpClientException.class, e -> {
+                        assertThat(e.getStatusCode()).isEqualTo(404);
+                    });
+        }
+    }
+
     private String randomSubject() {
         return "/books/" + UUID.randomUUID();
     }


### PR DESCRIPTION
Implements the readEventType endpoint to retrieve metadata for a specific event type from the event store. Unlike readEventTypes, this returns a single JSON object rather than an NDJSON stream.

Changes:
- Add EventTypeMetadata record with eventType, isPhantom, and schema (JsonNode)
- Add toReadEventTypeRequest and fromReadEventTypeResponse to Marshaller
- Implement readEventType in JacksonMarshaller with single JSON response handling
- Add readEventType method to EsdbClient using ofString body subscriber (like health())
- Add integration tests including 404 error handling for non-existent event types

The implementation follows the single-response pattern similar to health() and maintains full backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)