### PR TITLE
feat: Add registerEventSchema method to Metadata API

### DIFF
--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/EsdbClient.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/EsdbClient.java
@@ -237,6 +237,29 @@ public final class EsdbClient implements AutoCloseable {
                         null));
     }
 
+    /**
+     * Registers a JSON schema for a specific event type in the underlying event store. If a schema is already
+     * registered for the given event type, a {@link ClientException.HttpException.HttpClientException} with status code
+     * {@code 409} will be thrown.
+     *
+     * @param eventType the event type to register the schema for
+     * @param schema the JSON schema as {@link com.fasterxml.jackson.databind.JsonNode}
+     * @throws ClientException.TransportException in case of connection or network errors
+     * @throws ClientException.HttpException in case of errors depending on the HTTP status code, e.g. 409 if a schema
+     *     is already registered for the event type
+     * @throws ClientException.MarshallingException in case of serialization errors, typically caused by the associated
+     *     {@link Marshaller}
+     */
+    public void registerEventSchema(String eventType, com.fasterxml.jackson.databind.JsonNode schema)
+            throws ClientException {
+        HttpRequest httpRequest = newJsonRequest("/api/v1/register-event-schema")
+                .POST(HttpRequest.BodyPublishers.ofString(marshaller.toRegisterEventSchemaRequest(eventType, schema)))
+                .build();
+
+        httpRequestErrorHandler.handle(
+                httpRequest, headers -> HttpResponse.BodySubscribers.ofString(Util.fromHttpHeaders(headers)));
+    }
+
     private void checkValidOptions(Set<Class<? extends Option>> supported, Set<Option> requested) {
         Set<Class<? extends Option>> requestedOptionClasses =
                 requested.stream().map(Option::getClass).collect(Collectors.toSet());

--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/Marshaller.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/Marshaller.java
@@ -76,6 +76,16 @@ public interface Marshaller {
     ResponseElement fromReadOrObserveResponseLine(String line);
 
     /**
+     * Used by {@link EsdbClient#registerEventSchema(String, com.fasterxml.jackson.databind.JsonNode)} to transform the
+     * given event type and schema into a valid HTTP request body to be sent to the event store.
+     *
+     * @param eventType the event type to register the schema for
+     * @param schema the JSON schema
+     * @return the JSON HTTP request body as string
+     */
+    String toRegisterEventSchemaRequest(String eventType, com.fasterxml.jackson.databind.JsonNode schema);
+
+    /**
      * Sealed interface representing a deserialized ND-JSON response line transformed via
      * {@link #fromReadOrObserveResponseLine(String)}.
      *

--- a/esdb-client/src/main/java/com/opencqrs/esdb/client/jackson/JacksonMarshaller.java
+++ b/esdb-client/src/main/java/com/opencqrs/esdb/client/jackson/JacksonMarshaller.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opencqrs.esdb.client.*;
 import com.opencqrs.esdb.client.eventql.EventQueryProcessingError;
@@ -142,6 +143,15 @@ public class JacksonMarshaller implements Marshaller {
                             event.payload.hash,
                             event.payload.predecessorhash);
             };
+        } catch (JsonProcessingException e) {
+            throw new ClientException.MarshallingException(e);
+        }
+    }
+
+    @Override
+    public String toRegisterEventSchemaRequest(String eventType, JsonNode schema) {
+        try {
+            return objectMapper.writeValueAsString(Map.of("eventType", eventType, "schema", schema));
         } catch (JsonProcessingException e) {
             throw new ClientException.MarshallingException(e);
         }

--- a/esdb-client/src/test/java/com/opencqrs/esdb/client/EsdbClientIntegrationTest.java
+++ b/esdb-client/src/test/java/com/opencqrs/esdb/client/EsdbClientIntegrationTest.java
@@ -712,6 +712,34 @@ public class EsdbClientIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("/api/v1/register-event-schema")
+    public class RegisterEventSchema {
+
+        @Test
+        public void registerSchemaSuccessfully() throws Exception {
+            String eventType = "com.opencqrs.test-event.v" + UUID.randomUUID();
+            var schema =
+                    objectMapper.readTree("{\"type\": \"object\", \"properties\": {\"name\": {\"type\": \"string\"}}}");
+
+            assertThatCode(() -> client.registerEventSchema(eventType, schema)).doesNotThrowAnyException();
+        }
+
+        @Test
+        public void registeringSameSchemaAgainThrows409() throws Exception {
+            String eventType = "com.opencqrs.duplicate-test-event.v" + UUID.randomUUID();
+            var schema =
+                    objectMapper.readTree("{\"type\": \"object\", \"properties\": {\"id\": {\"type\": \"number\"}}}");
+
+            client.registerEventSchema(eventType, schema);
+
+            assertThatThrownBy(() -> client.registerEventSchema(eventType, schema))
+                    .isInstanceOfSatisfying(ClientException.HttpException.HttpClientException.class, e -> {
+                        assertThat(e.getStatusCode()).isEqualTo(409);
+                    });
+        }
+    }
+
     private String randomSubject() {
         return "/books/" + UUID.randomUUID();
     }


### PR DESCRIPTION
This commit implements the registerEventSchema method, allowing users to register JSON schemas for event types in the event store. The implementation includes:

- Extended Marshaller interface with toRegisterEventSchemaRequest method
- Implemented toRegisterEventSchemaRequest in JacksonMarshaller using JsonNode
- Added registerEventSchema void method to EsdbClient
- Added integration tests including HTTP 409 conflict handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)